### PR TITLE
Disable mccabe too since ruff provides this functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There also exists an [AUR package](https://aur.archlinux.org/packages/python-lsp
 
 # Usage
 
-This plugin will disable `flake8` and `pycodestyle` by default.
+This plugin will disable `flake8`, `pycodestyle` and `mccabe` by default.
 When enabled, all linting diagnostics will be provided by `ruff`.
 
 # Configuration

--- a/pylsp_ruff/ruff_lint.py
+++ b/pylsp_ruff/ruff_lint.py
@@ -20,7 +20,7 @@ UNNECESSITY_CODES = {
 
 @hookimpl
 def pylsp_settings():
-    # flake8 and pycodestyle disabled by default with this plugin
+    # this plugin disables flake8, mccabe, and pycodestyle by default
     return {
         "plugins": {
             "ruff": {
@@ -34,6 +34,7 @@ def pylsp_settings():
                 "select": None,
             },
             "flake8": {"enabled": False},
+            "mccabe": {"enabled": False},
             "pycodestyle": {"enabled": False},
         }
     }


### PR DESCRIPTION
It is preferable to disable the `mccabe` plugin in `pylsp` too, because `ruff` and therefore `pylsp-ruff` provides `mccabe`-like checking. Leaving the `mccabe` plugin enabled in `pylsp` may lead to confusing error messages.