### PR TITLE
Disable pyflakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There also exists an [AUR package](https://aur.archlinux.org/packages/python-lsp
 
 # Usage
 
-This plugin will disable `flake8`, `pycodestyle` and `mccabe` by default.
+This plugin will disable `flake8`, `pycodestyle`, `pyflakes` and `mccabe` by default.
 When enabled, all linting diagnostics will be provided by `ruff`.
 
 # Configuration

--- a/pylsp_ruff/ruff_lint.py
+++ b/pylsp_ruff/ruff_lint.py
@@ -33,6 +33,7 @@ def pylsp_settings():
                 "perFileIgnores": None,
                 "select": None,
             },
+            "pyflakes": {"enabled": False},
             "flake8": {"enabled": False},
             "mccabe": {"enabled": False},
             "pycodestyle": {"enabled": False},


### PR DESCRIPTION
This PR disables pyflakes and replaces the issue/question in #8.

Since flake8 is disabled, pyflakes should probably be disabled too since it's enabled by python-lsp-server by default.