### PR TITLE
Change the entry point name to `ruff`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+*.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 dev = ["pytest", "pre-commit"]
 
 [project.entry-points.pylsp]
-pylsp_ruff = "pylsp_ruff.ruff_lint"
+ruff = "pylsp_ruff.ruff_lint"
 
 [project.urls]
 "Homepage" = "https://github.com/python-lsp/python-lsp-ruff"


### PR DESCRIPTION
This will make the plugin name and options namespace to match, which will allow to disable the plugin as expected.

Fixes #11 