### PR TITLE
extendIgnore and server settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ When enabled, all linting diagnostics will be provided by `ruff`.
 
 Configuration options can be passed to the python-language-server. If a `pyproject.toml`
 file is present in the project, `python-lsp-ruff` will use these configuration options.
-Note that any configuration options passed to ruff via `pylsp` are ignored if the project has
-a `pyproject.toml`.
+Note that any configuration options (except for `extendIgnore` and `extendSelect`, see
+[this issue](https://github.com/python-lsp/python-lsp-ruff/issues/19)) passed to ruff via
+`pylsp` are ignored if the project has a `pyproject.toml`.
 
 The plugin follows [python-lsp-server's
 configuration](https://github.com/python-lsp/python-lsp-server/#configuration). These are
@@ -37,6 +38,7 @@ the valid configuration keys:
  - `pylsp.plugins.ruff.exclude`: Exclude files from being checked by `ruff`.
  - `pylsp.plugins.ruff.executable`: Path to the `ruff` executable. Assumed to be in PATH by default.
  - `pylsp.plugins.ruff.ignore`: Error codes to ignore.
+ - `pylsp.plugins.ruff.extendIgnore`: Same as ignore, but append to existing ignores.
  - `pylsp.plugins.ruff.lineLength`: Set the line-length for length checks.
  - `pylsp.plugins.ruff.perFileIgnores`: File-specific error codes to be ignored.
  - `pylsp.plugins.ruff.select`: List of error codes to enable.

--- a/pylsp_ruff/ruff_lint.py
+++ b/pylsp_ruff/ruff_lint.py
@@ -30,6 +30,7 @@ def pylsp_settings():
                 "exclude": None,
                 "executable": "ruff",
                 "ignore": None,
+                "extendIgnore": None,
                 "lineLength": None,
                 "perFileIgnores": None,
                 "select": None,
@@ -251,10 +252,11 @@ def load_config(workspace: Workspace, document: Document) -> dict:
             "exclude": None,
             "executable": _settings.get("executable", "ruff"),
             "ignore": None,
+            "extend-ignore": _settings.get("extendIgnore", None),
             "line-length": None,
             "per-file-ignores": None,
             "select": None,
-            "extend-select": None,
+            "extend-select": _settings.get("extendSelect", None),
         }
 
     else:
@@ -264,6 +266,7 @@ def load_config(workspace: Workspace, document: Document) -> dict:
             "exclude": _settings.get("exclude", None),
             "executable": _settings.get("executable", "ruff"),
             "ignore": _settings.get("ignore", None),
+            "extend-ignore": _settings.get("extendIgnore", None),
             "line-length": _settings.get("lineLength", None),
             "per-file-ignores": _settings.get("perFileIgnores", None),
             "select": _settings.get("select", None),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "python-lsp-ruff"
 authors = [
   {name = "Julian Hossbach", email = "julian.hossbach@gmx.de"}
 ]
-version = "1.1.0"
+version = "1.2.0"
 description = "Ruff linting plugin for pylsp"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/tests/test_ruff_lint.py
+++ b/tests/test_ruff_lint.py
@@ -78,7 +78,15 @@ def test_ruff_config_param(workspace):
         mock_instance.communicate.return_value = [bytes(), bytes()]
         ruff_conf = "/tmp/pyproject.toml"
         workspace._config.update(
-            {"plugins": {"ruff": {"config": ruff_conf, "extendSelect": ["D", "F"]}}}
+            {
+                "plugins": {
+                    "ruff": {
+                        "config": ruff_conf,
+                        "extendSelect": ["D", "F"],
+                        "extendIgnore": ["E"],
+                    }
+                }
+            }
         )
         _name, doc = temp_document(DOC, workspace)
         ruff_lint.pylsp_lint(workspace, doc)
@@ -86,6 +94,7 @@ def test_ruff_config_param(workspace):
         assert "ruff" in call_args
         assert f"--config={ruff_conf}" in call_args
         assert "--extend-select=D,F" in call_args
+        assert "--extend-ignore=E" in call_args
 
 
 def test_ruff_executable_param(workspace):
@@ -171,15 +180,25 @@ def f():
         "-",
     ]
 
+    workspace._config.update(
+        {
+            "plugins": {
+                "ruff": {
+                    "extendIgnore": ["D104"],
+                }
+            }
+        }
+    )
+
     diags = ruff_lint.pylsp_lint(workspace, doc)
 
     _list = []
     for diag in diags:
         _list.append(diag["code"])
-    # Assert that ignore and extend-select is working as intended
+    # Assert that ignore, extend-ignore and extend-select is working as intended
     assert "E402" in _list
     assert "D103" in _list
-    assert "D104" in _list
+    assert "D104" not in _list
     assert "F841" not in _list
 
     # Excludes


### PR DESCRIPTION
Resolves #19.
Does the following:
 - Add `extendIgnore` option
 - Allow `extendIgnore` and `extendSelect` to be used if a `pyproject.toml` is present