### PR TITLE
TOML dicts are formatted `{"tool" {"ruff": {..}}}`

### DIFF
--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -567,8 +567,10 @@ def load_settings(workspace: Workspace, document_path: str) -> PluginSettings:
         try:
             with open(pyproject_file[0], "rb") as f:
                 toml_dict = tomllib.load(f)
-            if "tool.ruff" in toml_dict:
-                config_in_pyproject = True
+
+                if "tool" in toml_dict and "ruff" in toml_dict["tool"]:
+                    config_in_pyproject = True
+
         except tomllib.TOMLDecodeError:
             log.warn("Error while parsing toml file, ignoring config.")
 

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -581,7 +581,7 @@ def load_settings(workspace: Workspace, document_path: str) -> PluginSettings:
         log.debug("Found existing configuration for ruff, skipping pylsp config.")
         # Leave config to pyproject.toml
         return PluginSettings(
-            enabled=plugin_settings.executable,
+            enabled=plugin_settings.enabled,
             executable=plugin_settings.executable,
             extend_ignore=plugin_settings.extend_ignore,
             extend_select=plugin_settings.extend_select,

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -567,10 +567,10 @@ def load_settings(workspace: Workspace, document_path: str) -> PluginSettings:
         try:
             with open(pyproject_file[0], "rb") as f:
                 toml_dict = tomllib.load(f)
+            if "tool.ruff" in toml_dict:
+                config_in_pyproject = True
         except tomllib.TOMLDecodeError:
             log.warn("Error while parsing toml file, ignoring config.")
-        if "tool.ruff" in toml_dict:
-            config_in_pyproject = True
 
     ruff_toml = find_parents(
         workspace.root_path, document_path, ["ruff.toml", ".ruff.toml"]


### PR DESCRIPTION
And not as `{"tool.ruff": {..}}`

This change will make sure that this boolean:

https://github.com/python-lsp/python-lsp-ruff/blob/f6707dfab9c39cbab23b8bc89646341164435afc/pylsp_ruff/plugin.py#L572-L573

will actually be set to `True` if a ruff config exists inside `pyproject.toml`

**Update**: I also added the config fixes commits of @martinal from #44 to this branch.

