### PR TITLE
settings: Don't try to disable flake8, document relevant limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There also exists an [AUR package](https://aur.archlinux.org/packages/python-lsp
 
 # Usage
 
-This plugin will disable `flake8`, `pycodestyle`, `pyflakes`, `mccabe` and `pyls_isort` by default.
+This plugin will disable `pycodestyle`, `pyflakes`, `mccabe` and `pyls_isort` by default, unless they are explicitly enabled in the client configuration.
 When enabled, all linting diagnostics will be provided by `ruff`.
 Sorting of the imports through `ruff` when formatting is enabled by default.
 The list of code fixes can be changed via the `pylsp.plugins.ruff.format` option.

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -64,12 +64,12 @@ DIAGNOSTIC_SEVERITIES = {
 @hookimpl
 def pylsp_settings():
     log.debug("Initializing pylsp_ruff")
-    # this plugin disables flake8, mccabe, and pycodestyle by default
+    # This plugin disables some enabled-by-default plugins that duplicate Ruff
+    # functionality
     settings = {
         "plugins": {
             "ruff": PluginSettings(),
             "pyflakes": {"enabled": False},
-            "flake8": {"enabled": False},
             "mccabe": {"enabled": False},
             "pycodestyle": {"enabled": False},
             "pyls_isort": {"enabled": False},


### PR DESCRIPTION
Removes flake8 from the list of `This plugin will disable [...] by default`. This doesn't change the existing behaviour at all:

The flake8 plugin is disabled by default in pylsp. If it's been enabled in the pylsp configuration then it's not actually possible for another plugin like this one to disable it.

The other four plugins disabled by python-lsp-ruff (pycodestyle, pyflakes, mccabe, pyls_isort) are enabled by default so the ruff plugin is able to disable these plugins, provided they're not explicitly enabled in the configuration.

Closes #46

Thanks for maintaining python-lsp-ruff, it's a very handy plugin! :grin: 