### PR TITLE
Support ruff 0.1.0

### DIFF
--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -492,7 +492,7 @@ def build_arguments(
     # Suppress update announcements
     args.append("--quiet")
     # Use the json formatting for easier evaluation
-    args.append("--format=json")
+    args.append("--output-format=json")
     if fix:
         args.append("--fix")
     else:

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -510,6 +510,9 @@ def build_arguments(
     if settings.line_length:
         args.append(f"--line-length={settings.line_length}")
 
+    if settings.unsafe_fixes:
+        args.append("--unsafe-fixes")
+
     if settings.exclude:
         args.append(f"--exclude={','.join(settings.exclude)}")
 
@@ -583,6 +586,7 @@ def load_settings(workspace: Workspace, document_path: str) -> PluginSettings:
         return PluginSettings(
             enabled=plugin_settings.enabled,
             executable=plugin_settings.executable,
+            unsafe_fixes=plugin_settings.unsafe_fixes,
             extend_ignore=plugin_settings.extend_ignore,
             extend_select=plugin_settings.extend_select,
             format=plugin_settings.format,

--- a/pylsp_ruff/settings.py
+++ b/pylsp_ruff/settings.py
@@ -9,6 +9,7 @@ from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, overrid
 class PluginSettings:
     enabled: bool = True
     executable: str = "ruff"
+    unsafe_fixes: bool = False
 
     config: Optional[str] = None
     line_length: Optional[int] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 license = {text = "MIT"}
 dependencies = [
-  "ruff>=0.0.267",
+  "ruff>=0.1.0, <0.2.0",
   "python-lsp-server",
   "lsprotocol>=2022.0.0a1",
   "tomli>=1.1.0; python_version < '3.11'",

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -115,6 +115,15 @@ def test_fix_all(workspace):
             pass
         """
     )
+    workspace._config.update(
+        {
+            "plugins": {
+                "ruff": {
+                    "unsafeFixes": True,
+                }
+            }
+        }
+    )
     _, doc = temp_document(codeaction_str, workspace)
     settings = ruff_lint.load_settings(workspace, doc.path)
     fixed_str = ruff_lint.run_ruff_fix(doc, settings)

--- a/tests/test_ruff_lint.py
+++ b/tests/test_ruff_lint.py
@@ -177,7 +177,7 @@ def f():
     assert call_args == [
         "ruff",
         "--quiet",
-        "--format=json",
+        "--output-format=json",
         "--no-fix",
         "--force-exclude",
         f"--stdin-filename={os.path.join(workspace.root_path, '__init__.py')}",


### PR DESCRIPTION
ruff 0.1.0 has [2 breaking changes](https://github.com/astral-sh/ruff/releases/tag/v0.1.0) that prevent python-lsp-ruff from working as-is:

- `--output` is now spelled `--output-format`
- Unsafe fixes are no longer applied unless explicitly enabled with `--unsafe-fixes`

This supports both of those changes so that users can upgrade to the newest ruff. _However_, this is going to be a pain in the neck for users: those fixes aren't backward compatible with older versions of ruff, so they'll need to upgrade python-lsp-ruff and ruff at the same time. I'm not sure what the alternative here. Maybe add a new mechanism to run `ruff --version` to see what command line args can be passed in? Gut it out because the [new semver policy](https://docs.astral.sh/ruff/versioning/) won't make future changes like this without bumping the minor version (which, in fairness, they did today)? I'll leave those decisions to you, oh wise maintainers! For now, I offer my humble patch to keep the spice flowing.