### PR TITLE
Ruff minor v change fixup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "python-lsp-ruff"
 authors = [
   {name = "Julian Hossbach", email = "julian.hossbach@gmx.de"}
 ]
-version = "1.5.2"
+version = "1.5.3"
 description = "Ruff linting plugin for pylsp"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 license = {text = "MIT"}
 dependencies = [
-  "ruff>=0.0.267",
+  "ruff>=0.0.267,<0.1.0",
   "python-lsp-server",
   "lsprotocol>=2022.0.0a1",
   "tomli>=1.1.0; python_version < '3.11'",


### PR DESCRIPTION
This is part of the regression introduced with `ruff 0.1.0`. Users can install `python-lsp-ruff v.1.5.3` to work with `ruff<0.1.0`, otherwise the upcoming version `v.1.6.0` should be used.