### PR TITLE
Support new ruff version, fix wrong call to ruff through PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ the valid configuration keys:
  - `pylsp.plugins.ruff.enabled`: boolean to enable/disable the plugin. `true` by default.
  - `pylsp.plugins.ruff.config`: Path to optional `pyproject.toml` file.
  - `pylsp.plugins.ruff.exclude`: Exclude files from being checked by `ruff`.
- - `pylsp.plugins.ruff.executable`: Path to the `ruff` executable. Assumed to be in PATH by default.
+ - `pylsp.plugins.ruff.executable`: Path to the `ruff` executable. Uses `os.executable -m "ruff"` by default.
  - `pylsp.plugins.ruff.ignore`: Error codes to ignore.
  - `pylsp.plugins.ruff.extendIgnore`: Same as ignore, but append to existing ignores.
  - `pylsp.plugins.ruff.lineLength`: Set the line-length for length checks.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ pip install python-lsp-ruff
 
 There also exists an [AUR package](https://aur.archlinux.org/packages/python-lsp-ruff).
 
-# Usage
+### When using ruff before version 0.1.0
+Ruff version `0.1.0` introduced API changes that are fixed in Python LSP Ruff `v1.6.0`. To continue with `ruff<0.1.0` please use `v1.5.3`, e.g. using `pip`:
+
+```sh
+pip install "ruff<0.1.0" "python-lsp-ruff==1.5.3"
+```
+
+## Usage
 
 This plugin will disable `pycodestyle`, `pyflakes`, `mccabe` and `pyls_isort` by default, unless they are explicitly enabled in the client configuration.
 When enabled, all linting diagnostics will be provided by `ruff`.
@@ -43,7 +50,7 @@ lspconfig.pylsp.setup {
 }
 ```
 
-# Configuration
+## Configuration
 
 Configuration options can be passed to the python-language-server. If a `pyproject.toml`
 file is present in the project, `python-lsp-ruff` will use these configuration options.
@@ -66,11 +73,12 @@ the valid configuration keys:
  - `pylsp.plugins.ruff.select`: List of error codes to enable.
  - `pylsp.plugins.ruff.extendSelect`: Same as select, but append to existing error codes.
  - `pylsp.plugins.ruff.format`: List of error codes to fix during formatting. The default is `["I"]`, any additional codes are appended to this list.
+ - `pylsp.plugins.ruff.unsafeFixes`: boolean that enables/disables fixes that are marked "unsafe" by `ruff`. `false` by default.
  - `pylsp.plugins.ruff.severities`: Dictionary of custom severity levels for specific codes, see [below](#custom-severities).
 
 For more information on the configuration visit [Ruff's homepage](https://beta.ruff.rs/docs/configuration/).
 
-## Custom severities
+### Custom severities
 
 By default, all diagnostics are marked as warning, except for `"E999"` and all error codes starting with `"F"`, which are displayed as errors.
 This default can be changed through the `pylsp.plugins.ruff.severities` option, which takes the error code as a key and any of

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -465,13 +465,15 @@ def run_ruff(
     executable = settings.executable
     arguments = build_arguments(document_path, settings, fix, extra_arguments)
 
-    log.debug(f"Calling {executable} with args: {arguments} on '{document_path}'")
-    try:
-        cmd = [executable]
-        cmd.extend(arguments)
-        p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-    except Exception:
-        log.debug(f"Can't execute {executable}. Trying with '{sys.executable} -m ruff'")
+    if executable is not None:
+        log.debug(f"Calling {executable} with args: {arguments} on '{document_path}'")
+        try:
+            cmd = [executable]
+            cmd.extend(arguments)
+            p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        except Exception:
+            log.error(f"Can't execute ruff with given executable '{executable}'.")
+    else:
         cmd = [sys.executable, "-m", "ruff"]
         cmd.extend(arguments)
         p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)

--- a/pylsp_ruff/ruff.py
+++ b/pylsp_ruff/ruff.py
@@ -19,6 +19,7 @@ class Edit:
 class Fix:
     edits: List[Edit]
     message: str
+    applicability: str
 
 
 @dataclass

--- a/pylsp_ruff/settings.py
+++ b/pylsp_ruff/settings.py
@@ -9,6 +9,7 @@ from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, overrid
 class PluginSettings:
     enabled: bool = True
     executable: str = "ruff"
+    unsafe_fixes: bool = False
 
     config: Optional[str] = None
     line_length: Optional[int] = None

--- a/pylsp_ruff/settings.py
+++ b/pylsp_ruff/settings.py
@@ -8,9 +8,7 @@ from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, overrid
 @dataclass
 class PluginSettings:
     enabled: bool = True
-    executable: str = "ruff"
-    unsafe_fixes: bool = False
-
+    executable: Optional[str] = None
     config: Optional[str] = None
     line_length: Optional[int] = None
 
@@ -24,6 +22,8 @@ class PluginSettings:
     per_file_ignores: Optional[Dict[str, List[str]]] = None
 
     format: Optional[List[str]] = None
+
+    unsafe_fixes: bool = False
 
     severities: Optional[Dict[str, str]] = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 license = {text = "MIT"}
 dependencies = [
-  "ruff>=0.0.267,<0.1.0",
+  "ruff>=0.1.0, <0.2.0",
   "python-lsp-server",
   "lsprotocol>=2022.0.0a1",
   "tomli>=1.1.0; python_version < '3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "python-lsp-ruff"
 authors = [
   {name = "Julian Hossbach", email = "julian.hossbach@gmx.de"}
 ]
-version = "1.5.3"
+version = "1.6.0"
 description = "Ruff linting plugin for pylsp"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -115,10 +115,39 @@ def test_fix_all(workspace):
             pass
         """
     )
+    expected_str_safe = dedent(
+        """
+        def f():
+            a = 2
+        """
+    )
+    workspace._config.update(
+        {
+            "plugins": {
+                "ruff": {
+                    "unsafeFixes": True,
+                }
+            }
+        }
+    )
     _, doc = temp_document(codeaction_str, workspace)
     settings = ruff_lint.load_settings(workspace, doc.path)
     fixed_str = ruff_lint.run_ruff_fix(doc, settings)
     assert fixed_str == expected_str
+
+    workspace._config.update(
+        {
+            "plugins": {
+                "ruff": {
+                    "unsafeFixes": False,
+                }
+            }
+        }
+    )
+    _, doc = temp_document(codeaction_str, workspace)
+    settings = ruff_lint.load_settings(workspace, doc.path)
+    fixed_str = ruff_lint.run_ruff_fix(doc, settings)
+    assert fixed_str == expected_str_safe
 
 
 def test_format_document_default_settings(workspace):

--- a/tests/test_ruff_lint.py
+++ b/tests/test_ruff_lint.py
@@ -177,7 +177,8 @@ def f():
     assert call_args == [
         "ruff",
         "--quiet",
-        "--format=json",
+        "--exit-zero",
+        "--output-format=json",
         "--no-fix",
         "--force-exclude",
         f"--stdin-filename={os.path.join(workspace.root_path, '__init__.py')}",

--- a/tests/test_ruff_lint.py
+++ b/tests/test_ruff_lint.py
@@ -2,6 +2,7 @@
 # Copyright 2021- Python Language Server Contributors.
 
 import os
+import sys
 import tempfile
 from unittest.mock import Mock, patch
 
@@ -154,7 +155,6 @@ def f():
     )
 
     # Check that user config is ignored
-    assert ruff_settings.executable == "ruff"
     empty_keys = [
         "config",
         "line_length",
@@ -175,6 +175,8 @@ def f():
 
     call_args = popen_mock.call_args[0][0]
     assert call_args == [
+        str(sys.executable),
+        "-m",
         "ruff",
         "--quiet",
         "--exit-zero",


### PR DESCRIPTION
This is a continuation of #48 since I want to capture all the new changes for the upcoming release in a version (and I didn't know renaming a branch closes a PR).

In particular, PR will
 - enable support for ruff `0.1.0` and the new configuration option `unsafe-fixes`, and
 - remove the now redundant call to `ruff` by lookup in the `PATH` and replace it with `sys.executable -m ruff` since this should be more reliable with different venv wrappers.


Closes #51. Closes #49.