### PR TITLE
[feat] Add setting for enabling/disabling Preview rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The plugin follows [python-lsp-server's
 configuration](https://github.com/python-lsp/python-lsp-server/#configuration). These are
 the valid configuration keys:
 
- - `pylsp.plugins.ruff.enabled`: boolean to enable/disable the plugin. `true` by default.
+ - `pylsp.plugins.ruff.enabled`: Boolean to enable/disable the plugin. `true` by default.
  - `pylsp.plugins.ruff.config`: Path to optional `pyproject.toml` file.
  - `pylsp.plugins.ruff.exclude`: Exclude files from being checked by `ruff`.
  - `pylsp.plugins.ruff.executable`: Path to the `ruff` executable. Uses `os.executable -m "ruff"` by default.
@@ -73,7 +73,8 @@ the valid configuration keys:
  - `pylsp.plugins.ruff.select`: List of error codes to enable.
  - `pylsp.plugins.ruff.extendSelect`: Same as select, but append to existing error codes.
  - `pylsp.plugins.ruff.format`: List of error codes to fix during formatting. The default is `["I"]`, any additional codes are appended to this list.
- - `pylsp.plugins.ruff.unsafeFixes`: boolean that enables/disables fixes that are marked "unsafe" by `ruff`. `false` by default.
+ - `pylsp.plugins.ruff.unsafeFixes`: Boolean that enables/disables fixes that are marked "unsafe" by `ruff`. `false` by default.
+ - `pylsp.plugins.ruff.preview`: Boolean that enables/disables rules & fixes that are marked "preview" by `ruff`. `false` by default.
  - `pylsp.plugins.ruff.severities`: Dictionary of custom severity levels for specific codes, see [below](#custom-severities).
 
 For more information on the configuration visit [Ruff's homepage](https://beta.ruff.rs/docs/configuration/).

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -533,6 +533,9 @@ def build_arguments(
     if settings.line_length:
         args.append(f"--line-length={settings.line_length}")
 
+    if settings.preview:
+        args.append("--preview")
+
     if settings.unsafe_fixes:
         args.append("--unsafe-fixes")
 

--- a/pylsp_ruff/settings.py
+++ b/pylsp_ruff/settings.py
@@ -23,6 +23,7 @@ class PluginSettings:
 
     format: Optional[List[str]] = None
 
+    preview: bool = False
     unsafe_fixes: bool = False
 
     severities: Optional[Dict[str, str]] = None


### PR DESCRIPTION
Added a setting for enabling/disabling [ruff Preview rules](https://docs.astral.sh/ruff/preview/)

This enables it for both `lint` and `format` actions, though `format` is not something this plugin supports for now. It doesn not seem that ruff supports different `--preview` flags for linting / formatting as of now.

Should likely be revisited if  https://github.com/python-lsp/python-lsp-ruff/issues/53 is being pursued :-)

