### PR TITLE
Remove python v3.7 testing from CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,14 +12,14 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: python -m pip install -e .[dev]
     - name: pre-commit checks
-      uses: pre-commit/action@v2.0.2
+      uses: pre-commit/action@v3.0.0
     - name: Tests
       run: pytest -v tests/


### PR DESCRIPTION
Based on https://github.com/python-lsp/python-lsp-ruff/pull/56#issuecomment-1800335566 