### PR TITLE
Add target version and preview to formatter

### DIFF
--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -646,6 +646,15 @@ def build_format_arguments(
     if settings.exclude:
         args.append(f"--exclude={','.join(settings.exclude)}")
 
+    if settings.preview:
+        args.append("--preview")
+
+    if settings.line_length:
+        args.append(f"--line-length={settings.line_length}")
+
+    if settings.target_version:
+        args.append(f"--target-version={settings.target_version}")
+
     if extra_arguments:
         args.extend(extra_arguments)
 


### PR DESCRIPTION
Adds the `preview` and the `targetVersion` settings to `ruff format`