### PR TITLE
Add pattern matching to severities

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,5 +94,4 @@ This default can be changed through the `pylsp.plugins.ruff.severities` option, 
 For more information on the diagnostic severities please refer to
 [the official LSP reference](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnosticSeverity).
 
-Note that `python-lsp-ruff` does *not* accept regex, and it will *not* check whether the error code exists. If the custom severity level is not displayed,
-please check first that the error code is correct and that the given value is one of the possible keys from above.
+With `v2.0.0` it is also possible to use patterns to match codes. Rules match if the error code starts with the given pattern. If multiple patterns match the error code, `python-lsp-ruff` chooses the one with the most amount of matching characters.

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -207,10 +207,18 @@ def create_diagnostic(check: RuffCheck, settings: PluginSettings) -> Diagnostic:
     if check.code == "E999" or check.code[0] == "F":
         severity = DiagnosticSeverity.Error
 
-    # Override severity with custom severity if possible, use default otherwise
+    # Check if check.code starts contained in given severities
     if settings.severities is not None:
-        custom_sev = settings.severities.get(check.code, None)
-        if custom_sev is not None:
+        _custom_sev = [
+            sev
+            for pat, sev in sorted(
+                settings.severities.items(), key=lambda key: (len(key), key)
+            )
+            if check.code.startswith(pat)
+        ]
+
+        if _custom_sev:
+            custom_sev = _custom_sev[-1]
             severity = DIAGNOSTIC_SEVERITIES.get(custom_sev, severity)
 
     tags = []

--- a/tests/test_ruff_lint.py
+++ b/tests/test_ruff_lint.py
@@ -195,7 +195,7 @@ def f():
             "plugins": {
                 "ruff": {
                     "extendIgnore": ["D104"],
-                    "severities": {"E402": "E", "D103": "I"},
+                    "severities": {"E402": "E", "D": "I", "D1": "H"},
                 }
             }
         }
@@ -217,7 +217,7 @@ def f():
         if diag["code"] == "E402":
             assert diag["severity"] == 1
         if diag["code"] == "D103":
-            assert diag["severity"] == 3
+            assert diag["severity"] == 4  # Should take "D1" over "D"
 
     # Excludes
     doc_uri = uris.from_fs_path(os.path.join(workspace.root_path, "blah/__init__.py"))


### PR DESCRIPTION
Allows to add loose severity codes to match all rules that start with the given pattern.
`D` would e.g. match **all** codes starting with `D`. If e.g. `D` and `D1` are given, any rule matching both would take the more precise one, so `D1` over `D`.