### PR TITLE
Fall back to python module if ruff executable is missing

### DIFF
--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -510,6 +510,7 @@ def run_ruff(
 
     arguments = subcommand.build_args(document_path, settings, fix, extra_arguments)
 
+    p = None
     if executable is not None:
         log.debug(f"Calling {executable} with args: {arguments} on '{document_path}'")
         try:
@@ -518,7 +519,11 @@ def run_ruff(
             p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
         except Exception:
             log.error(f"Can't execute ruff with given executable '{executable}'.")
-    else:
+    if p is None:
+        log.debug(
+            f"Calling ruff via '{sys.executable} -m ruff'"
+            f" with args: {arguments} on '{document_path}'"
+        )
         cmd = [sys.executable, "-m", "ruff", str(subcommand)]
         cmd.extend(arguments)
         p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)


### PR DESCRIPTION
There are a couple of ways to fix #69.
* return an empty string after logging the error on line 520;
* fall back to running ruff via the python module (similar to previous behaviour, but with the option to not even attempt to run the executable if it's not specified).

This fix implements the second option as that will provide a better user experience. This assumes commit ea5f874a was simply intended to shortcut the attempt to call the executable if it was not set, rather than intended to remove the fallback behaviour.

Assigning to the `p` variable prior to opening pipes and checking for a `None` value felt like a better option than skipping the initial assignment and then trying to detect whether the variable has had a value assigned.