### PR TITLE
Allow ruff 0.2.x; disable default enabled formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install "ruff<0.1.0" "python-lsp-ruff==1.5.3"
 
 ## Usage
 
-This plugin will disable `pycodestyle`, `pyflakes`, `mccabe`, `pyls_isort`, `autopep8`, and `yapf` by default, unless they are explicitly enabled in the client configuration.
+This plugin will disable `pycodestyle`, `pyflakes`, `mccabe`, `autopep8`, and `yapf` by default, unless they are explicitly enabled in the client configuration.
 When `python-lsp-ruff` is enabled, all linting diagnostics and formatting capabilities will be provided by `ruff`.
 
 Any codes given in the `format` option will only be marked as `fixable` for ruff during the formatting operation, the user has to make sure that these codes are also in the list of codes that ruff checks!

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python](https://github.com/python-lsp/python-lsp-ruff/actions/workflows/python.yml/badge.svg)](https://github.com/python-lsp/python-lsp-ruff/actions/workflows/python.yml)
 
 `python-lsp-ruff` is a plugin for `python-lsp-server` that adds linting, code action and formatting capabilities that are provided by [ruff](https://github.com/charliermarsh/ruff),
-an extremely fast Python linter written in Rust.
+an extremely fast Python linter and formatter written in Rust.
 
 ## Install
 
@@ -26,8 +26,8 @@ pip install "ruff<0.1.0" "python-lsp-ruff==1.5.3"
 
 ## Usage
 
-This plugin will disable `pycodestyle`, `pyflakes`, `mccabe` and `pyls_isort` by default, unless they are explicitly enabled in the client configuration.
-When enabled, all linting diagnostics will be provided by `ruff`.
+This plugin will disable `pycodestyle`, `pyflakes`, `mccabe`, `pyls_isort`, `autopep8`, and `yapf` by default, unless they are explicitly enabled in the client configuration.
+When `python-lsp-ruff` is enabled, all linting diagnostics and formatting capabilities will be provided by `ruff`.
 
 Any codes given in the `format` option will only be marked as `fixable` for ruff during the formatting operation, the user has to make sure that these codes are also in the list of codes that ruff checks!
 
@@ -38,7 +38,7 @@ Configuration options can be passed to the python-language-server. If a `pyproje
 file is present in the project, `python-lsp-ruff` will ignore specific options (see below).
 
 The plugin follows [python-lsp-server's configuration](https://github.com/python-lsp/python-lsp-server/#configuration).
-This example configuration using for `neovim` shows the possible optionsL
+This example configuration using for `neovim` shows the possible options:
 
 ```lua
 pylsp = {

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -97,7 +97,6 @@ def pylsp_settings():
             "pyflakes": {"enabled": False},
             "mccabe": {"enabled": False},
             "pycodestyle": {"enabled": False},
-            "pyls_isort": {"enabled": False},
             "yapf": {"enabled": False},
             "autopep8": {"enabled": False},
         }

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -98,6 +98,8 @@ def pylsp_settings():
             "mccabe": {"enabled": False},
             "pycodestyle": {"enabled": False},
             "pyls_isort": {"enabled": False},
+            "yapf": {"enabled": False},
+            "autopep8": {"enabled": False},
         }
     }
     return converter.unstructure(settings)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "MIT"}
 dependencies = [
-  "ruff>=0.1.5, <0.3.0",
+  "ruff>=0.2.0, <0.3.0",
   "python-lsp-server",
 	"cattrs!=23.2.1",
   "lsprotocol>=2022.0.0a1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "MIT"}
 dependencies = [
-  "ruff>=0.1.5, <0.2.0",
+  "ruff>=0.1.5, <0.3.0",
   "python-lsp-server",
 	"cattrs!=23.2.1",
   "lsprotocol>=2022.0.0a1",


### PR DESCRIPTION
This fixes https://github.com/python-lsp/python-lsp-ruff/issues/79 - there are no deprecated/breaking changes that affects `python-lsp-ruff`, so we can safely bump to include `ruff` 0.2.x

And now that `ruff` has a formatter that is enabled by default, we should disable the default-enabled formatters, like `python-lsp-black` does: 
https://github.com/python-lsp/python-lsp-black/blob/307e87dbf74ff0227991d88cbc734113ce3fff68/pylsp_black/plugin.py#L60-L61

(I had an annoying issue with these and ruff fighting)

Ref: https://astral.sh/blog/ruff-v0.2.0 - https://github.com/astral-sh/ruff/releases/tag/v0.2.0