### PR TITLE
Bump to v2.1.0 in pyproject, update deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,4 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.8.0
-    hooks:
-      - id: black
-
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.991
     hooks:
@@ -11,9 +6,12 @@ repos:
         args: [--ignore-missing-imports]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.158
+    rev: v0.2.1
     hooks:
+      # Run the linter.
       - id: ruff
+      # Run the formatter.
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "python-lsp-ruff"
 authors = [
   {name = "Julian Hossbach", email = "julian.hossbach@gmx.de"}
 ]
-version = "2.0.2"
+version = "2.1.0"
 description = "Ruff linting plugin for pylsp"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,3 @@ ruff = "pylsp_ruff.plugin"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
-
-[tool.black]
-target-version = ['py36', 'py37', 'py38', 'py39', 'py310', 'py311']
-line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "ruff>=0.2.0, <0.3.0",
   "python-lsp-server",
 	"cattrs!=23.2.1",
-  "lsprotocol>=2022.0.0a1",
+  "lsprotocol>=2023.0.1",
   "tomli>=1.1.0; python_version < '3.11'",
 ]
 


### PR DESCRIPTION
 - Bump to version 2.1.0 with the new patch version in ruff
 - Move to ruff for performing CI, remove black
 - Use the new version of `lsprotocol` that avoid the `cattrs` bug in #61.