### PR TITLE
Make including unsafe fixes among code actions the default

### DIFF
--- a/pylsp_ruff/settings.py
+++ b/pylsp_ruff/settings.py
@@ -24,7 +24,7 @@ class PluginSettings:
     format: Optional[List[str]] = None
 
     preview: bool = False
-    unsafe_fixes: bool = False
+    unsafe_fixes: bool = True
 
     severities: Optional[Dict[str, str]] = None
 


### PR DESCRIPTION
It is convenient to include unsafe fixes among code actions. Because they are marked `(unsafe)` and including them does not affect the action `Fix All`, there is little reason not to. Herefor, this behaviour ought to be the default.