### PR TITLE
Relax ruff constraints to allow installing next to ruff 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "MIT"}
 dependencies = [
-  "ruff>=0.2.0, <0.3.0",
+  "ruff>=0.2.0, <0.4.0",
   "python-lsp-server",
 	"cattrs!=23.2.1",
   "lsprotocol>=2023.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "MIT"}
 dependencies = [
-  "ruff>=0.2.0, <0.4.0",
+  "ruff>=0.2.0",
   "python-lsp-server",
 	"cattrs!=23.2.1",
   "lsprotocol>=2023.0.1",


### PR DESCRIPTION
Seems to work fine and unit tests all pass on the new ruff 0.3.0 release.