### PR TITLE
Fix fixall title suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 __pycache__/
 *.egg-info/
+
+*.swp
+tags
+/build/

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -405,7 +405,7 @@ def create_fix_all_code_action(
     document: Document,
     settings: PluginSettings,
 ) -> CodeAction:
-    title = "Ruff: Fix All (all safe fixes)"
+    title = "Ruff: Fix All (safe fixes)"
     kind = CodeActionKind.SourceFixAll
 
     # No unsafe fixes for 'Fix all', see https://github.com/python-lsp/python-lsp-ruff/issues/55

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -106,8 +106,7 @@ def pylsp_settings():
 
 @hookimpl(hookwrapper=True)
 def pylsp_format_document(workspace: Workspace, document: Document) -> Generator:
-    """
-    Provide formatting through ruff.
+    """Provide formatting through ruff.
 
     Parameters
     ----------
@@ -115,6 +114,7 @@ def pylsp_format_document(workspace: Workspace, document: Document) -> Generator
         Current workspace.
     document : pylsp.workspace.Document
         Document to apply ruff on.
+
     """
     log.debug(f"textDocument/formatting: {document}")
     outcome = yield
@@ -158,8 +158,7 @@ def pylsp_format_document(workspace: Workspace, document: Document) -> Generator
 
 @hookimpl
 def pylsp_lint(workspace: Workspace, document: Document) -> List[Dict]:
-    """
-    Register ruff as the linter.
+    """Register ruff as the linter.
 
     Parameters
     ----------
@@ -171,6 +170,7 @@ def pylsp_lint(workspace: Workspace, document: Document) -> List[Dict]:
     Returns
     -------
     List of dicts containing the diagnostics.
+
     """
     settings = load_settings(workspace, document.path)
     checks = run_ruff_check(document=document, settings=settings)
@@ -179,8 +179,7 @@ def pylsp_lint(workspace: Workspace, document: Document) -> List[Dict]:
 
 
 def create_diagnostic(check: RuffCheck, settings: PluginSettings) -> Diagnostic:
-    """
-    Create a LSP diagnostic based on the given RuffCheck object.
+    """Create a LSP diagnostic based on the given RuffCheck object.
 
     Parameters
     ----------
@@ -192,6 +191,7 @@ def create_diagnostic(check: RuffCheck, settings: PluginSettings) -> Diagnostic:
     Returns
     -------
     Diagnostic
+
     """
     # Adapt range to LSP specification (zero-based)
     range = Range(
@@ -248,8 +248,7 @@ def pylsp_code_actions(
     range: Dict,
     context: Dict,
 ) -> List[Dict]:
-    """
-    Provide code actions through ruff.
+    """Provide code actions through ruff.
 
     Parameters
     ----------
@@ -267,6 +266,7 @@ def pylsp_code_actions(
     Returns
     -------
     List of dicts containing the code actions.
+
     """
     log.debug(f"textDocument/codeAction: {document} {range} {context}")
 
@@ -307,9 +307,6 @@ def pylsp_code_actions(
 
     checks = run_ruff_check(document=document, settings=settings)
     checks_with_fixes = [c for c in checks if c.fix]
-    checks_with_fixall = [
-        c for c in checks_with_fixes if c.fix and c.fix.applicability == "safe"
-    ]
     checks_organize_imports = [c for c in checks_with_fixes if c.code == "I001"]
 
     if not has_organize_imports and checks_organize_imports:
@@ -325,7 +322,7 @@ def pylsp_code_actions(
             ]
         )
 
-    if checks_with_fixall:
+    if any([c.fix.applicability == "safe" for c in checks_with_fixes]):  # type: ignore
         code_actions.append(
             create_fix_all_code_action(document=document, settings=settings),
         )
@@ -490,8 +487,7 @@ def run_ruff(
     fix: bool = False,
     extra_arguments: Optional[List[str]] = None,
 ) -> str:
-    """
-    Run ruff on the given document and the given arguments.
+    """Run ruff on the given document and the given arguments.
 
     Parameters
     ----------
@@ -512,6 +508,7 @@ def run_ruff(
     Returns
     -------
     String containing the result in json format.
+
     """
     executable = settings.executable
 
@@ -548,8 +545,7 @@ def build_check_arguments(
     fix: bool = False,
     extra_arguments: Optional[List[str]] = None,
 ) -> List[str]:
-    """
-    Build arguments for ruff check.
+    """Build arguments for ruff check.
 
     Parameters
     ----------
@@ -565,6 +561,7 @@ def build_check_arguments(
     Returns
     -------
     List containing the arguments.
+
     """
     args = []
     # Suppress update announcements
@@ -634,8 +631,7 @@ def build_format_arguments(
     settings: PluginSettings,
     extra_arguments: Optional[List[str]] = None,
 ) -> List[str]:
-    """
-    Build arguments for ruff format.
+    """Build arguments for ruff format.
 
     Parameters
     ----------
@@ -649,6 +645,7 @@ def build_format_arguments(
     Returns
     -------
     List containing the arguments.
+
     """
     args = []
     # Suppress update announcements
@@ -684,8 +681,7 @@ def build_format_arguments(
 
 
 def load_settings(workspace: Workspace, document_path: str) -> PluginSettings:
-    """
-    Load settings from pyproject.toml file in the project path.
+    """Load settings from pyproject.toml file in the project path.
 
     Parameters
     ----------
@@ -697,6 +693,7 @@ def load_settings(workspace: Workspace, document_path: str) -> PluginSettings:
     Returns
     -------
     PluginSettings read via lsp.
+
     """
     config = workspace._config
     _plugin_settings = config.plugin_settings("ruff", document_path=document_path)

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -405,7 +405,7 @@ def create_fix_all_code_action(
     document: Document,
     settings: PluginSettings,
 ) -> CodeAction:
-    title = "Ruff: Fix All"
+    title = "Ruff: Fix All (all safe fixes)"
     kind = CodeActionKind.SourceFixAll
 
     # No unsafe fixes for 'Fix all', see https://github.com/python-lsp/python-lsp-ruff/issues/55

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -307,6 +307,9 @@ def pylsp_code_actions(
 
     checks = run_ruff_check(document=document, settings=settings)
     checks_with_fixes = [c for c in checks if c.fix]
+    checks_with_fixall = [
+        c for c in checks_with_fixes if c.fix and c.fix.applicability == "safe"
+    ]
     checks_organize_imports = [c for c in checks_with_fixes if c.code == "I001"]
 
     if not has_organize_imports and checks_organize_imports:
@@ -322,7 +325,7 @@ def pylsp_code_actions(
             ]
         )
 
-    if checks_with_fixes:
+    if checks_with_fixall:
         code_actions.append(
             create_fix_all_code_action(document=document, settings=settings),
         )

--- a/pylsp_ruff/ruff.py
+++ b/pylsp_ruff/ruff.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Union
+from typing import List, Optional
 
 
 @dataclass
@@ -29,4 +29,4 @@ class Check:
     filename: str
     location: Location
     end_location: Location
-    fix: Union[Fix, None] = None
+    fix: Optional[Fix] = None

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -47,12 +47,12 @@ codeactions = [
     "Ruff (F401): Disable for this line",
     "Ruff (F841): Remove assignment to unused variable `a` (unsafe)",
     "Ruff (F841): Disable for this line",
-    "Ruff: Fix All (all safe fixes)",
+    "Ruff: Fix All (safe fixes)",
 ]
 
 codeactions_import = [
     "Ruff: Organize imports",
-    "Ruff: Fix All (all safe fixes)",
+    "Ruff: Fix All (safe fixes)",
     "Ruff (I001): Disable for this line",
 ]
 

--- a/tests/test_code_actions.py
+++ b/tests/test_code_actions.py
@@ -47,12 +47,12 @@ codeactions = [
     "Ruff (F401): Disable for this line",
     "Ruff (F841): Remove assignment to unused variable `a` (unsafe)",
     "Ruff (F841): Disable for this line",
-    "Ruff: Fix All",
+    "Ruff: Fix All (all safe fixes)",
 ]
 
 codeactions_import = [
     "Ruff: Organize imports",
-    "Ruff: Fix All",
+    "Ruff: Fix All (all safe fixes)",
     "Ruff (I001): Disable for this line",
 ]
 


### PR DESCRIPTION
clear the 'fix all' meaning:
1, actually it is a 'term' which the 'all' meant all safe fixes only.
2, somehow some '(unsafe)' marker e.g F841 maybe would not be added, vs adding 'all safe fixes' suffix to 'fix all' probably would be a more direct meaning title.