### PR TITLE
Update deprecated e999 check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.10.1
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.2.1
+    rev: v0.5.2
     hooks:
       # Run the linter.
       - id: ruff

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -210,7 +210,7 @@ def create_diagnostic(check: RuffCheck, settings: PluginSettings) -> Diagnostic:
     # Ruff intends to implement severity codes in the future,
     # see https://github.com/charliermarsh/ruff/issues/645.
     severity = DiagnosticSeverity.Warning
-    if check.code == "None" or check.code[0] == "F":
+    if check.code == "None" or check.code == "E999" or check.code[0] == "F":
         severity = DiagnosticSeverity.Error
 
     # Check if check.code starts contained in given severities

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -210,7 +210,7 @@ def create_diagnostic(check: RuffCheck, settings: PluginSettings) -> Diagnostic:
     # Ruff intends to implement severity codes in the future,
     # see https://github.com/charliermarsh/ruff/issues/645.
     severity = DiagnosticSeverity.Warning
-    if check.code == "E999" or check.code[0] == "F":
+    if check.code == "None" or check.code[0] == "F":
         severity = DiagnosticSeverity.Error
 
     # Check if check.code starts contained in given severities


### PR DESCRIPTION
`E999` has been deprecated in ruff v0.5 and was replaced with `null` which translates to `"None"` in our package. Check instead if the code is `"None"`.