### PR TITLE
notfy: give ack. about ruff linter and formatter

### DIFF
--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -117,19 +117,19 @@ def pylsp_format_document(workspace: Workspace, document: Document) -> Generator
 
     """
 
+    log.debug(f"textDocument/formatting: {document}")
+    outcome = yield
+    result = outcome.get_result()
+    if result:
+        source = result[0]["newText"]
+    else:
+        source = document.source
+
+    settings = load_settings(workspace=workspace, document_path=document.path)
+    if not settings.format_enabled:
+        return
+
     with workspace.report_progress("format: ruff"):
-        log.debug(f"textDocument/formatting: {document}")
-        outcome = yield
-        result = outcome.get_result()
-        if result:
-            source = result[0]["newText"]
-        else:
-            source = document.source
-
-        settings = load_settings(workspace=workspace, document_path=document.path)
-        if not settings.format_enabled:
-            return
-
         new_text = run_ruff_format(
             settings=settings, document_path=document.path, document_source=source
         )

--- a/pylsp_ruff/plugin.py
+++ b/pylsp_ruff/plugin.py
@@ -140,7 +140,9 @@ def pylsp_format_document(workspace: Workspace, document: Document) -> Generator
             # specifying `format = ["I"]` to get import sorting as part of formatting.
             new_text = run_ruff(
                 settings=PluginSettings(
-                    ignore=["ALL"], select=settings.format, executable=settings.executable
+                    ignore=["ALL"],
+                    select=settings.format,
+                    executable=settings.executable,
                 ),
                 document_path=document.path,
                 document_source=new_text,


### PR DESCRIPTION
Like inbuilt plugins, ruff will also inform about linter and formatter working

it is actually useful because it inform user that pylsp is working properly and format is also working 