### PR TITLE
Add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+
+## Supported Versions
+
+We normally support only the most recently released version with bug fixes, security updates and compatibility improvements.
+
+
+## Reporting a Vulnerability
+
+If you believe you've discovered a security vulnerability in this project, please open a new security advisory with [our GitHub repo's private vulnerability reporting](https://github.com/python-lsp/python-lsp-ruff/security/advisories/new).
+Please be sure to carefully document the vulnerability, including a summary, describing the impacts, identifying the line(s) of code affected, stating the conditions under which it is exploitable and including a minimal reproducible test case.
+Further information and advice or patches on how to mitigate it is always welcome.
+You can usually expect to hear back within 1 week, at which point we'll inform you of our evaluation of the vulnerability and what steps we plan to take, and will reach out if we need further clarification from you.
+We'll discuss and update the advisory thread, and are happy to update you on its status should you further inquire.
+While this is a volunteer project and we don't have financial compensation to offer, we can certainly publicly thank and credit you for your help if you would like.
+Thanks!


### PR DESCRIPTION
Add a baseline security policy, based on what we use across the rest of the Spyder and Python-LSP org.